### PR TITLE
test: Use the published version of the xblock-sdk.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,6 @@
-xblock-sdk==0.5.4
 bok-choy==1.1.1
+edx-lint==5.3.2
+mock==5.0.1
+pytest==7.2.1
 selenium==3.141.0
+xblock-sdk==0.5.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
--e 'git+https://github.com/openedx/xblock-sdk.git@v0.5.4#egg=xblock-sdk==v0.5.4'
+xblock-sdk==0.5.4
 bok-choy==1.1.1
 selenium==3.141.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ allowlist_externals =
 commands_pre =
   pip install -r requirements.txt
   pip install -r test_requirements.txt
-  make -C {envdir}/src/xblock-sdk/ install
 
 [testenv:unit]
 commands =


### PR DESCRIPTION
We publish this to PyPI so there's no reason to install this from
github.
