### PR TITLE
feat!: remove Transifex calls for FC-0012 - OEP-58

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,0 @@
-[main]
-host = https://www.transifex.com
-
-[o:open-edx:p:xblocks:r:image-explorer]
-file_filter = image_explorer/translations/<lang>/LC_MESSAGES/text.po
-source_file = image_explorer/translations/en/LC_MESSAGES/text.po
-source_lang = en
-type        = PO

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,3 @@ dummy_translations: ## generate dummy translation (.po) files
 build_dummy_translations: dummy_translations compile_translations ## generate and compile dummy translation files
 
 validate_translations: build_dummy_translations detect_changed_source_translations ## validate translations
-
-pull_translations: ## pull translations from transifex
-	tx pull -t -a -f --mode reviewed --minimum-perc=1
-
-push_translations: ## push translations to transifex
-	tx push -s

--- a/README.md
+++ b/README.md
@@ -219,16 +219,6 @@ Example image explorer return value:
 },
 ```
 
-Downloading translations from Transifex
--------------------------------------
-
-If you want to download translations from Transifex install [Transifex client][transifex-client] and run this command while inside project root directory
-```
-tx pull -f --mode=reviewed -l en,ar,es_419,fr,he,hi,ko_KR,pt_BR,ru,zh_CN
-```
-
-[transifex-client]: https://docs.transifex.com/client/installing-the-client
-
 License
 -------
 


### PR DESCRIPTION
Breaking change!
---

This change breaks the Jenkins transifex integration which has been deprecated in favor of the new GitHub Transifex App integration as part of [OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Changes
---

- [x] Create a separate PR to remove source and language translations from the repositories, hence no `.po` or `.mo` files will be committed into the repos. https://github.com/openedx/xblock-image-explorer/pull/114
- [x] Removes direct use of `tx pull` and `tx push` commands from the [XBlock to let Open edX manage it](https://github.com/openedx/edx-platform/pull/33166).
- [x] Remove Transifex related `Makefile` targets and configuration files.
- [ ] ~~Use the OEP-58 JavaScript translations from the Open edX platform~~ NA
- [ ] ~~Remove `transifex-client` from requirements~~ NA

Merge timeline
---

This should only be merged after [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification) is fully implemented.

The timing announcement will be shared by @brian-smith-tcril on [#translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T) Open edX Slack channel.

**## Keep this pull request as a draft to prevent an accidental merge. ##**

Pre-merge checklist
---

- [ ] https://github.com/openedx/wg-translations/issues/20 is approved

References
---

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.