### PR TITLE
fix: remove deprecated xblock.fragment import

### DIFF
--- a/image_explorer/__init__.py
+++ b/image_explorer/__init__.py
@@ -22,4 +22,4 @@ Image Explorer XBlock
 """
 from .image_explorer import ImageExplorerBlock
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -37,7 +37,11 @@ from lxml import etree, html
 from parsel import Selector
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
-from xblock.fragment import Fragment
+try:
+    from web_fragments.fragment import Fragment
+except:
+    # for backwards compatibility with quince and prior releases
+    from xblock.fragment import Fragment
 from xblock.fields import List, Scope, String, Boolean
 
 from .utils import loader, AttrDict, _


### PR DESCRIPTION
## Description
This replace `xblock.fragment` with `web_fragments.fragment`. `xblock.fragment` was [removed as of 2024-02-26](https://docs.openedx.org/projects/xblock/en/latest/changelog.html#id2). If this xblock is used in a course, the entire course will fail to load.