### PR TITLE
chore: Drop py3.8 support | replace pkg_resource lib with importlib.resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: ['3.8', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
         toxenv: [django42, quality, package]
 
     steps:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install Dependencies
         run: pip install -r requirements/pip.txt

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -30,7 +30,7 @@ import logging
 import textwrap
 from io import StringIO
 from urllib.parse import urljoin
-import pkg_resources
+import importlib.resources
 
 from django.conf import settings
 from lxml import etree, html
@@ -465,5 +465,5 @@ class ImageExplorerBlock(XBlock):
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
-        data = pkg_resources.resource_string(__name__, path)
-        return data.decode("utf8")
+        data = importlib.resources.files(__package__).joinpath(path)
+        return data.read_text(encoding="utf-8")

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,6 @@ setup(
     long_description_content_type='text/markdown',
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
@@ -127,5 +126,5 @@ setup(
     },
     packages=['image_explorer'],
     package_data=package_data("image_explorer", ["static", "templates", "public", "translations"]),
-    python_requires=">=3.8",
+    python_requires=">=3.11",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,311,312}-django{42},quality,package
+envlist = py{311,312}-django{42},quality,package
 
 [pytest]
 DJANGO_SETTINGS_MODULE = workbench.settings


### PR DESCRIPTION
 - Drop Py3.8 support
 - Replace pkg_resources lib with importlib.resources

**Ticket:** [Move on from deprecated pkg_resources api #150](https://github.com/openedx/xblock-image-explorer/issues/150)

<mark>PR is expected to merge after merging this PR : [chore: Upgrade Python requirements](https://github.com/openedx/xblock-image-explorer/pull/151)</mark>

Followed migration guide: https://importlib-resources.readthedocs.io/en/latest/migration.html

**Testing:**
I have tested the changes with following steps:

 - Install xblock-image-explorer into xblock-sdk
 - Test image explorer xblock functionality
 - Run tox tests

**Screenshot after changes**
![image](https://github.com/user-attachments/assets/6be566f4-d869-4d23-ab52-bfaa356a2eb8)
