### PR TITLE
build: add Django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [django42, quality, package]
+        toxenv: [django42, django52, quality, package]
 
     steps:
     - name: checkout repo

--- a/image_explorer/__init__.py
+++ b/image_explorer/__init__.py
@@ -22,4 +22,4 @@ Image Explorer XBlock
 """
 from .image_explorer import ImageExplorerBlock
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
     ],
     url='https://github.com/openedx/xblock-image-explorer',
     install_requires=load_requirements('requirements/base.in'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-django{42},quality,package
+envlist = py{311,312}-django{42,52},quality,package
 
 [pytest]
 DJANGO_SETTINGS_MODULE = workbench.settings
@@ -10,6 +10,7 @@ allowlist_externals =
     mkdir
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     mkdir -p var


### PR DESCRIPTION
This adds Django 5.2 to the testing pipelines.

Resolves https://github.com/openedx/xblock-image-explorer/issues/189