### PR TITLE
fix: Adds lxml version to be supported by parsel.

### DIFF
--- a/image_explorer/__init__.py
+++ b/image_explorer/__init__.py
@@ -22,4 +22,4 @@ Image Explorer XBlock
 """
 from .image_explorer import ImageExplorerBlock
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,4 @@
 -c constraints.txt
 
 xblock[django]
-parsel==v1.6
-cssselect==v1.2
+parsel

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,4 +2,5 @@
 -c constraints.txt
 
 xblock[django]
-parsel
+parsel==v1.6
+cssselect==v1.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ botocore==1.37.37
     #   s3transfer
 cssselect==1.2.0
     # via
-    #   -r requirements/base.in
+    #   -c requirements/constraints.txt
     #   parsel
 django==4.2.20
     # via
@@ -48,7 +48,9 @@ markupsafe==3.0.2
 openedx-django-pyfs==3.7.0
     # via xblock
 parsel==1.6.0
-    # via -r requirements/base.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 python-dateutil==2.9.0.post0
     # via
     #   botocore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,8 +14,10 @@ botocore==1.37.37
     # via
     #   boto3
     #   s3transfer
-cssselect==1.3.0
-    # via parsel
+cssselect==1.2.0
+    # via
+    #   -r requirements/base.in
+    #   parsel
 django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -31,7 +33,6 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-    #   parsel
 lazy==1.6
     # via xblock
 lxml==5.3.2
@@ -46,9 +47,7 @@ markupsafe==3.0.2
     #   xblock
 openedx-django-pyfs==3.7.0
     # via xblock
-packaging==25.0
-    # via parsel
-parsel==1.10.0
+parsel==1.6.0
     # via -r requirements/base.in
 python-dateutil==2.9.0.post0
     # via
@@ -66,6 +65,7 @@ six==1.17.0
     # via
     #   fs
     #   fs-s3fs
+    #   parsel
     #   python-dateutil
 sqlparse==0.5.3
     # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,4 +10,5 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
+parsel==v1.6
+cssselect==v1.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,5 +10,19 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+#
+# Parsel needs to know the lxml version https://github.com/scrapy/parsel/blob/master/parsel/selector.py#L35.
+# Since this information was not being passed and etree flavor of openedx doesn't open version for outside
+# we had to pin parsel which doesn't have this code branch.
+#
+# And this version of parsel has cssselect which doesn't expose
+# '_unicode_safe_getattr' hence we had to pin cssselect to the required version.
+#
+# This issue has been explained in https://github.com/openedx/xblock-image-explorer/pull/195#issuecomment-2844971682
+#
+# This can be removed once we resolve
+# https://github.com/openedx/xblock-image-explorer/issues/197#issue-3048741312,
+# one of the ways to do is to remove the dependency on Parsel as explained in
+# https://github.com/openedx/xblock-image-explorer/pull/195#pullrequestreview-2808751843
 parsel==v1.6
 cssselect==v1.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -49,7 +49,7 @@ cookiecutter==2.6.0
     # via xblock-sdk
 coverage[toml]==7.8.0
     # via pytest-cov
-cssselect==1.3.0
+cssselect==1.2.0
     # via
     #   -r requirements/base.txt
     #   parsel
@@ -88,7 +88,6 @@ jmespath==1.0.1
     #   -r requirements/base.txt
     #   boto3
     #   botocore
-    #   parsel
 lazy==1.6
     # via
     #   -r requirements/base.txt
@@ -122,11 +121,8 @@ openedx-django-pyfs==3.7.0
     #   -r requirements/base.txt
     #   xblock
 packaging==25.0
-    # via
-    #   -r requirements/base.txt
-    #   parsel
-    #   pytest
-parsel==1.10.0
+    # via pytest
+parsel==1.6.0
     # via -r requirements/base.txt
 pbr==6.1.1
     # via stevedore
@@ -203,6 +199,7 @@ six==1.17.0
     #   edx-lint
     #   fs
     #   fs-s3fs
+    #   parsel
     #   python-dateutil
 sqlparse==0.5.3
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -51,6 +51,7 @@ coverage[toml]==7.8.0
     # via pytest-cov
 cssselect==1.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   parsel
 dill==0.4.0
@@ -123,7 +124,9 @@ openedx-django-pyfs==3.7.0
 packaging==25.0
     # via pytest
 parsel==1.6.0
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 pbr==6.1.1
     # via stevedore
 platformdirs==4.3.7


### PR DESCRIPTION
Parsel needs to know the lxml version
https://github.com/scrapy/parsel/blob/master/parsel/selector.py#L35. Since this information was not being passed and etree flavor of openedx doesn't open __version__ for outside we had to add a hardcoded value in the library.

~~**Dependencies**: None~~

~~**Screenshots**: Always include screenshots if there is any change to the UI.~~

~~**Sandbox URL**: TBD - sandbox is being provisioned.~~

~~**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.~~

**Testing instructions**:

1.  Use Tutor to set up Sumac.2 (Use Tutor's release branch instead of main)
2. Clone this repo under (tutor config printroot)/env/build/openedx/requirements/
3. Add private.txt and add `-e ./xblock-image-explorer` in that file.
4. Mount this repository `tutor mounts add ./xblock-image-explorer`
5. Build the image `tutor images build openedx-dev`
6. Now start the dev environment with `tutor dev start -d`
7. Exec in the container `tutor dev exec cms bash`
8. Then run  `./manage.py lms shell`
9. 
```python
In [1]: from xblock.core import XBlock
In [2]: XBlock.load_class('image-explorer')
```
11. This should load with errors without the changes in the PR. 
12. Once you change the branch in the PR you need to exec in the container
13. `pip install -e /mnt/xblock-image-explorer`
14. Repeat 9 again, this time it will load without error.